### PR TITLE
refactor: rename validation `handle` to `strictHandle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ const workflow = withValidation(createWorkflow(), [
   [[startEvent], [parseEvent]],
 ]);
 
-workflow.handle([startEvent], (sendEvent, start) => {
+workflow.strictHandle([startEvent], (sendEvent, start) => {
   sendEvent(
     disallowedEvent.with(), // <-- ❌ Type Check Failed, Runtime Error
   );

--- a/packages/fluere/src/core/workflow.ts
+++ b/packages/fluere/src/core/workflow.ts
@@ -30,7 +30,7 @@ export type WorkflowMutatorIdentifier = keyof WorkflowMutators<
 export type WorkflowCreator<
   Mis extends [] = [],
   Mos extends [] = [],
-> = ({}) => Workflow<Mis, Mos>;
+> = () => Workflow<Mis, Mos>;
 
 export const createWorkflow: WorkflowCreator = (): Workflow => {
   const config = {

--- a/packages/fluere/src/middleware/validation.ts
+++ b/packages/fluere/src/middleware/validation.ts
@@ -1,5 +1,4 @@
 import {
-  type WorkflowContext,
   getContext,
   type Handler,
   type Workflow,
@@ -37,7 +36,7 @@ export type WithValidationWorkflow<
     output: WorkflowEvent<any>[],
   ][],
 > = {
-  handle<
+  strictHandle<
     const AcceptEvents extends WorkflowEvent<any>[],
     Result extends ReturnType<WorkflowEvent<any>["with"]> | void,
   >(
@@ -55,7 +54,7 @@ export function withValidation<
 >(
   workflow: WorkflowLike,
   validation: Validation,
-): WithValidationWorkflow<Validation> & Omit<WorkflowLike, "handle"> {
+): WithValidationWorkflow<Validation> & WorkflowLike {
   const createSafeSendEvent = (...events: WorkflowEventData<any>[]) => {
     const outputs = validation
       .filter(([inputs]) =>
@@ -82,7 +81,7 @@ export function withValidation<
   };
   return {
     ...workflow,
-    handle: (accept, handler) => {
+    strictHandle: (accept, handler) => {
       const wrappedHandler: Handler<WorkflowEvent<any>[], any> = (
         ...events
       ) => {

--- a/packages/fluere/tests/middleware/full-workflow.spec.ts
+++ b/packages/fluere/tests/middleware/full-workflow.spec.ts
@@ -45,7 +45,7 @@ describe("full workflow middleware", () => {
       [[[startEvent], [stopEvent]]],
       () => ({}),
     );
-    workflow.handle([startEvent], (sendEvent, events) => {
+    workflow.strictHandle([startEvent], (sendEvent, events) => {
       // @ts-expect-error
       sendEvent(messageEvent.with());
       sendEvent(stopEvent.with(""));
@@ -65,7 +65,7 @@ describe("full workflow middleware", () => {
         id,
       }),
     );
-    workflow.handle([startEvent], (sendEvent, start) => {
+    workflow.strictHandle([startEvent], (sendEvent, start) => {
       expect(start.data).toBe("start");
       sendEvent(stopEvent.with(workflow.getStore().id));
     });

--- a/packages/fluere/tests/middleware/with-validation.spec.ts
+++ b/packages/fluere/tests/middleware/with-validation.spec.ts
@@ -31,7 +31,7 @@ describe("with directed graph", () => {
     ]);
     const fn = vi.fn();
 
-    workflow.handle([startEvent], (sendEvent) => {
+    workflow.strictHandle([startEvent], (sendEvent) => {
       fn();
       sendEvent(
         // @ts-expect-error
@@ -65,7 +65,7 @@ describe("with directed graph", () => {
       [[startEvent], [stopEvent]],
     ]);
 
-    workflow.handle([startEvent], (sendEvent) => {
+    workflow.strictHandle([startEvent], (sendEvent) => {
       sendEvent(stopEvent.with(1));
     });
 


### PR DESCRIPTION
For typescript happy, probably change first parameter is not allowed